### PR TITLE
Enhanced tide support

### DIFF
--- a/scripts/BeachComberUtilities.ash
+++ b/scripts/BeachComberUtilities.ash
@@ -741,6 +741,54 @@ void analyze_rarities(boolean verbose)
 }
 
 // ***************************
+//          Tide Chart       *
+// ***************************
+
+void print_tide_chart()
+{
+    int daycount = daycount();
+    int date = now_to_int();
+    int millis = 24 * 60 * 60 * 1000;
+
+    buffer table;
+
+    table.append("<html>");
+    table.append("<table border=1>");
+
+    table.append("<tr>");
+    table.append("<th>Date</th>");
+    table.append("<th>Direction</th>");
+    table.append("<th>Covered</th>");
+    table.append("</tr>");
+
+    for (int i = 0; i < 8; i++) {
+	string current_date = timestamp_to_date(date, "yyyyMMdd");
+	tides current_tides = current_tides(daycount);
+
+	table.append("<tr>");
+	table.append("<td>");
+	table.append(current_date);
+	table.append("</td>");
+	table.append("<td>");
+	table.append(current_tides.direction);
+	table.append("</td>");
+	table.append("<td>");
+	table.append(current_tides.covered);
+	table.append("</td>");
+	table.append("</tr>");
+
+	date += millis;
+	daycount++;
+   }
+
+    table.append("</table>");
+    table.append("</html>");
+
+    print();
+    print_html(table);
+}
+
+// ***************************
 //    Beach Set utilities    *
 // ***************************
 
@@ -825,6 +873,7 @@ void main(string... parameters)
     boolean verbose = false;
     boolean complete = false;
     boolean rarities = false;
+    boolean tide_chart = false;
     beach minutes = 0;
 
     void parse_parameters(string... parameters)
@@ -843,6 +892,9 @@ void main(string... parameters)
 		continue;
 	    case "rarities":
 		rarities = true;
+		continue;
+	    case "tides":
+		tide_chart = true;
 		continue;
 	    }
 
@@ -889,6 +941,11 @@ void main(string... parameters)
 
     if (rarities) {
 	analyze_rarities(verbose);
+	return;
+    }
+
+    if (tide_chart) {
+	print_tide_chart();
 	return;
     }
 


### PR DESCRIPTION
BeachCombing depends on tides, which come in and go out over an 8 day cycle.
We no longer depend on the ```_beachTides``` setting to tell us where they are; we can derive it from KoL's daycount.

1) BeachComberData does the calculation for us.
2) BeachComber uses that and also provides ```BeachComber tides```:
```
The tides came in today and 3 rows of the beach are now washed by waves.
```
3) ```BeachComberUtilities tides``` will print a little tide chart:

Date | Direction | Covered
-- | -- | --
20250506 | in | 3
20250507 | in | 4
20250508 | out | 3
20250509 | out | 2
20250510 | out | 1
20250511 | out | 0
20250512 | in | 1
20250513 | in | 2

